### PR TITLE
feat: Add CD pipelines for the application

### DIFF
--- a/.github/actions/build-docker/action.yaml
+++ b/.github/actions/build-docker/action.yaml
@@ -1,15 +1,16 @@
 name: Build docker image
 description: Builds docker image and pushes it to dockerhub
 inputs:
-  tags:
+  tag:
     required: true
     default: 'latest'
   username:
     required: true
   password:
     required: true
-  token:
-    required: true
+outputs:
+  build-digest:
+    value: ${{ steps.build.outputs.digest }}
 runs:
   using: 'composite'
   steps: 
@@ -28,20 +29,4 @@ runs:
         with:
           context: .
           push: true
-          tags: mimotej/go-jamf:${{ inputs.tags }}
-      - name: Find Comment
-        uses: peter-evans/find-comment@v3
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Link to DockerHub image
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            📦 Link to DockerHub image: "https://hub.docker.com/layers/mimotej/go-jamf/${{ inputs.tags }}/images/${{ steps.build.outputs.digest }}"
-          edit-mode: replace
-          token: ${{ inputs.token}}
+          tags: mimotej/go-jamf:${{ inputs.tag }}

--- a/.github/actions/prepare-pr/action.yaml
+++ b/.github/actions/prepare-pr/action.yaml
@@ -1,0 +1,57 @@
+name: Prepare deployment
+description: Prepares deployment of the application PR
+inputs:
+  tag:
+    required: true
+    default: 'latest'
+  PAT:
+    required: true
+  repo:
+    required: true
+  file:
+    required: true
+    default:  values.yaml
+  release:
+    required: false
+    default: false
+  release-version:
+    required: false
+outputs:
+  pr-link:
+    value: ${{ steps.setup-pr.outputs.pull-request-url }}
+runs:
+  using: 'composite'
+  steps: 
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repo }}
+        path: 'manifests'
+    - name: Move to workspace folder
+      shell: bash
+      run: |
+        cd {{ $GITHUB_WORKSPACE }}/manifests
+    - name: Update image tag
+      id: update-image-tag
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq -i '.image.tag' = "${{ inputs.tag }}" apps/go-jamf/${{ inputs.file }}
+    - name: Update version
+      id: update-release-version
+      if: ${{ inputs.release }} == true
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq -i '.appVersion' = "${{ inputs.release-version }}" apps/go-jamf/Chart.yaml
+    - name: Setup PR
+      id: setup-pr
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ inputs.PAT }}
+        commit-message: "chore: Update go-jamf manifests tag: ${{ inputs.tag }}"
+        branch: update-manifets
+        delete-branch: true
+        title: Update manifests
+        body: |
+          This PR is automatically generated. Action that created this PR can be found here: https://github.com/mimotej/jamf-go/actions.
+
+        

--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -1,0 +1,37 @@
+name: PR
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  pull-requests: write
+jobs:
+  deploy:
+    if: (github.event.issue.pull_request &&  contains(github.event.comment.body, '/deploy'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare PR
+        id: prepare-pr
+        uses: ./.github/actions/prepare-pr
+        with:
+          tag: pr-${{ github.event.number }}-${{ github.sha }}
+          PAT: ${{ secrets.PAT }}
+          repo: 'mimotej/jamf-manifests'
+          file: 'values-dev.yaml'
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: PR to updated deployment
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Hello 👋
+            ➡️ Here is PR to updated deployment: ${{ steps.prepare-pr.outputs.pr-link }}
+            ✅ Just merge it to deploy new version.
+          edit-mode: replace
+          token: ${{ secrets.GITHUB_TOKEN }}      

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,11 +20,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build and push
         uses: ./.github/actions/build-docker
+        id: build
         with: 
-          tags: "pr-${{ github.event.number }}-${{ github.sha }}"
+          tag: "pr-${{ github.event.number }}-${{ github.sha }}"
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Link to DockerHub image
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            📦 Link to DockerHub image: "https://hub.docker.com/layers/mimotej/go-jamf/pr-${{ github.event.number }}-${{ github.sha }}/images/${{ steps.build.outputs.build-digest }}"
+          edit-mode: replace
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR:

[X] adjust behavior of default workflow
[X] creates a new workflow that allows usage of /deploy command which then creates PR against manifest repo with changed manifests for dev instance
