### PR TITLE
feat: Add release pipeline for application

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,7 @@
+---
+name: New release
+title: New semantic release
+labels: release
+---
+
+Create a new release.

--- a/.github/actions/prepare-pr-release/action.yaml
+++ b/.github/actions/prepare-pr-release/action.yaml
@@ -11,6 +11,8 @@ inputs:
   file:
     required: true
     default:  values.yaml
+  release-version:
+    required: true
 outputs:
   pr-link:
     value: ${{ steps.setup-pr.outputs.pull-request-url }}
@@ -35,6 +37,12 @@ runs:
       shell: bash
       run: |
         yq -i '.image.tag = "${{ inputs.tag }}"' $GITHUB_WORKSPACE/manifests/apps/go-jamf/${{ inputs.file }}
+    - name: Update version
+      id: update-release-version
+      if: ${{ inputs.release }} == true
+      shell: bash
+      run: |
+        yq -i '.appVersion = "${{ inputs.release-version }}"' $GITHUB_WORKSPACE/manifests/apps/go-jamf/Chart.yaml
     - name: Setup PR
       id: setup-pr
       uses: peter-evans/create-pull-request@v7

--- a/.github/actions/test-build/action.yaml
+++ b/.github/actions/test-build/action.yaml
@@ -1,0 +1,15 @@
+name: Test uild docker image
+description: Test builds docker image 
+runs:
+  using: 'composite'
+  steps: 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/build-docker
         id: build
         with: 
-          tags: "mimotej/go-jamf:pr-${{ github.event.number }}-${{ github.event.commit_id }},mimotej/go-jamf:${{ github.event.number }}-latest"
+          tags: "mimotej/go-jamf:pr-${{ github.event.number }}-${{ github.sha }},mimotej/go-jamf:pr-${{ github.event.number }}-latest"
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Find Comment
@@ -35,12 +35,13 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Link to DockerHub image
+      
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            📦 Link to DockerHub image: "https://hub.docker.com/layers/mimotej/go-jamf/pr-${{ github.event.number }}-${{ github.event.commit_id }}/images/${{ steps.build.outputs.build-digest }}"
+            📦 Link to DockerHub image: "https://hub.docker.com/layers/mimotej/go-jamf/pr-${{ github.event.number }}-${{ github.sha }}/images/${{ steps.build.outputs.build-digest }}"
           edit-mode: replace
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,168 @@
+name: Release
+
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  verify-user:
+    outputs:
+      comment: ${{ steps.comment.outputs.comment-id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Checkif release issue
+        if: ${{ !contains(github.event.issue.labels.*.name, 'release') }}
+        continue-on-error: true
+        id: releaseLabel
+        shell: bash
+        run: exit 1
+      - name: "Check if user has write access"
+        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        id: access
+        continue-on-error: true
+        with:
+          permission: "write"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Close Issue
+        uses: peter-evans/close-issue@v2
+        if: ${{ !steps.access.outcome == 'failure' }}
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ✋ You do not have rights to run this action @${{ github.event.issue.user.id }}. ✋
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Exit on failure
+        if: ${{ steps.access.outcome == 'failure'}}
+        shell: bash
+        run: exit 1
+      - name: Create starting comment
+        uses: peter-evans/create-or-update-comment@v2
+        id: comment
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            👷‍♂️ Job started [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) hold tight!.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  test-lint:
+    outputs:
+      comment: ${{ steps.comment-ok.outputs.comment-id }}
+    runs-on: ubuntu-latest
+    needs: verify-user
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test
+        id: test
+        uses: ./.github/actions/test
+        continue-on-error: true
+      - name: GolangCI lint
+        id: lint
+        uses: golangci/golangci-lint-action@v6
+        continue-on-error: true
+        with:
+          version: v1.61.0
+      - name: Test build
+        id: test-build
+      - name: Update commment
+        uses: peter-evans/close-issue@v2
+        if: (${{ success() }} || ${{ failure() }}) && (${{ steps.test.outcome }} == 'failure' || ${{ steps.lint.outcome }} == 'failure'  || ${{ steps.test-build.outcome }} == 'failure')
+        id: comment-fail
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-id: ${{ needs.verify-user.outputs.comment }}
+          body: |
+            ❌ Sorry tests failed!.❌
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update commment
+        uses: peter-evans/create-or-update-comment@v2
+        id: comment-ok
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-id: ${{ needs.verify-user.outputs.comment }}
+          body: |
+            ✅ Tests ok!.✅
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release:
+    outputs:
+      comment: ${{ steps.comment-ok.outputs.comment-id }}
+      release-version: ${{ steps.semantic-release.outputs.new_release_version }}
+    needs:
+      - verify-user
+      - test-lint
+    steps:
+      - name: Update commment
+        uses: peter-evans/create-or-update-comment@v2
+        id: comment
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-id: ${{ needs.test-lint.outputs.comment }}
+          body: |
+            ✅ Preparing release.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release via semantic-release
+        uses: cycjimmy/semantic-release-action@v2
+        id: semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update comment
+        uses: peter-evans/close-issue@v2
+        if: ${{ steps.semantic.outputs.new_release_published != 'true' }}
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-id: ${{ steps.comment.outputs.comment-id }}
+          body: |
+            ⛔ No release needed, closing
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    needs:
+      - verify-user
+      - test-lint
+      - release
+    steps:
+      - name: Build and push
+        uses: ./.github/actions/build-docker
+        id: build
+        with: 
+          tags: "mimotej/go-jamf:${{ needs.release.outputs.release-version }},mimotej/go-jamf:$latest"
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Prepare PR DEV
+        id: prepare-pr-dev
+        uses: ./.github/actions/prepare-pr
+        with:
+          tag: "${{ needs.release.outputs.release-version }}"
+          PAT: "${{ secrets.PAT }}"
+          repo: 'mimotej/jamf-manifests'
+          file: 'values-dev.yaml'
+      - name: Prepare PR release
+        id: prepare-pr-release
+        uses: ./.github/actions/prepare-pr-release
+        with:
+          tag: "${{ needs.release.outputs.release-version }}"
+          PAT: "${{ secrets.PAT }}"
+          repo: 'mimotej/jamf-manifests'
+          file: 'values.yaml'
+          release-version: "${{ needs.release.outputs.release-version }}"
+      - name: Create or update comment
+        uses: peter-evans/close-issue@v2
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-id: ${{ needs.release.outputs.comment }}
+          body: |
+            ✅ Build done!
+            📦 Link to DockerHub image: "https://hub.docker.com/layers/mimotej/go-jamf/${{ needs.release.outputs.release-version }}/images/${{ steps.build.outputs.build-digest }}"
+            🏗️ Dev instance PR: ${{ steps.prepare-pr-dev.outputs.pr-link }}
+            🖥️ Prod instance PR: ${{ steps.prepare-pr-release.outputs.pr-link }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+
+        


### PR DESCRIPTION
This PR creates basic release pipeline, workflow of this pipeline was inspired by https://github.com/operate-first/peribolos-as-a-service and general workflow is:
[X] Verify user 
[X] Run tests, testing build, linting
[X] Prepare release
[X] Run final build with push
[X] Inform user by comments